### PR TITLE
Add absorption detection indicator a8

### DIFF
--- a/NinjaTrader.Custom.csproj
+++ b/NinjaTrader.Custom.csproj
@@ -377,6 +377,7 @@
     <Compile Include="Indicators\a2.cs" />
     <Compile Include="Indicators\a3.cs" />
     <Compile Include="Indicators\a7.cs" />
+    <Compile Include="Indicators\a8.cs" />
     <Compile Include="Indicators\footprint.cs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
## Summary
- rename `a6` indicator to `a8`
- integrate absorption detection with Tick Replay validation
- expose configuration properties for absorption logic
- maintain delta/volume rendering with new detection signals
- include `a8` in project build

## Testing
- `dotnet build` *(fails: `dotnet` not found)*