### PR TITLE
Add VWAP band options to a1 indicator

### DIFF
--- a/Indicators/a1.cs
+++ b/Indicators/a1.cs
@@ -41,6 +41,14 @@ namespace NinjaTrader.NinjaScript.Indicators
         [Display(Name = "Show Session VWAP", Order = 0, GroupName = "Session VWAP")]
         public bool ShowSession { get; set; } = false;
 
+        [NinjaScriptProperty]
+        [Display(Name = "Show Bands 1 (±1σ)", Order = 1, GroupName = "Session VWAP")]
+        public bool ShowSessionBands1 { get; set; } = false;
+
+        [NinjaScriptProperty]
+        [Display(Name = "Show Bands 2 (±2σ)", Order = 2, GroupName = "Session VWAP")]
+        public bool ShowSessionBands2 { get; set; } = false;
+
         // Anchored VWAP
         [NinjaScriptProperty]
         [Display(Name = "Show Anchored VWAP", Order = 0, GroupName = "Anchored VWAP")]
@@ -59,7 +67,7 @@ namespace NinjaTrader.NinjaScript.Indicators
         // Weekly accumulators
         private double wSumPV, wSumV, wSumVarPV;
         // Session accumulators
-        private double sSumPV, sSumV;
+        private double sSumPV, sSumV, sSumVarPV;
         // Anchored accumulators
         private double aSumPV, aSumV;
         private bool   anchorActive;
@@ -81,15 +89,19 @@ namespace NinjaTrader.NinjaScript.Indicators
 
                 DrawOnPricePanel = true;
 
-                // Plots: 0-4 Weekly, 5 Session, 6 Anchored
+                // Plots: 0-4 Weekly, 5 Session, 6 Anchored, 7-10 Session bands
                 AddPlot(Brushes.Blue,       "Weekly VWAP");    // Values[0]
                 AddPlot(Brushes.Green,      "+1σ");           // Values[1]
                 AddPlot(Brushes.Green,      "-1σ");           // Values[2]
                 AddPlot(Brushes.Green,      "+2σ");           // Values[3]
                 AddPlot(Brushes.Green,      "-2σ");           // Values[4]
 
-                AddPlot(Brushes.DeepSkyBlue, "Session VWAP");  // Values[5]
-                AddPlot(Brushes.Goldenrod,  "Anchored VWAP");  // Values[6]
+                AddPlot(Brushes.Blue,       "Session VWAP");  // Values[5]
+                AddPlot(Brushes.Yellow,     "Anchored VWAP");  // Values[6]
+                AddPlot(Brushes.Purple,     "Session +1σ");   // Values[7]
+                AddPlot(Brushes.Purple,     "Session -1σ");   // Values[8]
+                AddPlot(Brushes.Purple,     "Session +2σ");   // Values[9]
+                AddPlot(Brushes.Purple,     "Session -2σ");   // Values[10]
             }
         }
 
@@ -100,7 +112,7 @@ namespace NinjaTrader.NinjaScript.Indicators
             if (Bars.IsFirstBarOfSession)
             {
                 // reset diario (Session)
-                sSumPV = sSumV = 0;
+                sSumPV = sSumV = sSumVarPV = 0;
                 if (Time[0].DayOfWeek == DayOfWeek.Sunday)          // ajusta si prefieres Monday
                 {
                     // reset semanal (Weekly)
@@ -123,6 +135,8 @@ namespace NinjaTrader.NinjaScript.Indicators
             sSumPV += ohlc4 * vol;
             sSumV  += vol;
             double sVWAP = sSumV == 0 ? ohlc4 : sSumPV / sSumV;
+            sSumVarPV += vol * Math.Pow(ohlc4 - sVWAP, 2);
+            double sSigma = sSumV == 0 ? 0 : Math.Sqrt(sSumVarPV / sSumV);
 
             // Anchored
             DateTime anchorDT = AnchorDateTime;
@@ -177,7 +191,38 @@ namespace NinjaTrader.NinjaScript.Indicators
             }
 
             // ─── Ploteo Session ───
-            Values[5][0] = ShowSession ? sVWAP : double.NaN;
+            if (ShowSession)
+            {
+                Values[5][0] = sVWAP;
+
+                if (ShowSessionBands1)
+                {
+                    Values[7][0] = sVWAP + sSigma;
+                    Values[8][0] = sVWAP - sSigma;
+
+                    if (ShowSessionBands2)
+                    {
+                        Values[9][0]  = sVWAP + 2 * sSigma;
+                        Values[10][0] = sVWAP - 2 * sSigma;
+                    }
+                    else
+                    {
+                        Values[9][0]  = double.NaN;
+                        Values[10][0] = double.NaN;
+                    }
+                }
+                else
+                {
+                    for (int i = 7; i <= 10; i++)
+                        Values[i][0] = double.NaN;
+                }
+            }
+            else
+            {
+                Values[5][0] = double.NaN;
+                for (int i = 7; i <= 10; i++)
+                    Values[i][0] = double.NaN;
+            }
 
             // ─── Ploteo Anchored ───
             Values[6][0] = (ShowAnchored && anchorActive) ? aVWAP : double.NaN;
@@ -192,19 +237,19 @@ namespace NinjaTrader.NinjaScript.Indicators
 	public partial class Indicator : NinjaTrader.Gui.NinjaScript.IndicatorRenderBase
 	{
 		private a1[] cachea1;
-		public a1 a1(bool showWeekly, bool showWeeklyBands1, bool showWeeklyBands2, bool showSession, bool showAnchored, DateTime anchorDate, string anchorTime)
-		{
-			return a1(Input, showWeekly, showWeeklyBands1, showWeeklyBands2, showSession, showAnchored, anchorDate, anchorTime);
-		}
+                public a1 a1(bool showWeekly, bool showWeeklyBands1, bool showWeeklyBands2, bool showSession, bool showSessionBands1, bool showSessionBands2, bool showAnchored, DateTime anchorDate, string anchorTime)
+                {
+                        return a1(Input, showWeekly, showWeeklyBands1, showWeeklyBands2, showSession, showSessionBands1, showSessionBands2, showAnchored, anchorDate, anchorTime);
+                }
 
-		public a1 a1(ISeries<double> input, bool showWeekly, bool showWeeklyBands1, bool showWeeklyBands2, bool showSession, bool showAnchored, DateTime anchorDate, string anchorTime)
-		{
-			if (cachea1 != null)
-				for (int idx = 0; idx < cachea1.Length; idx++)
-					if (cachea1[idx] != null && cachea1[idx].ShowWeekly == showWeekly && cachea1[idx].ShowWeeklyBands1 == showWeeklyBands1 && cachea1[idx].ShowWeeklyBands2 == showWeeklyBands2 && cachea1[idx].ShowSession == showSession && cachea1[idx].ShowAnchored == showAnchored && cachea1[idx].AnchorDate == anchorDate && cachea1[idx].AnchorTime == anchorTime && cachea1[idx].EqualsInput(input))
-						return cachea1[idx];
-			return CacheIndicator<a1>(new a1(){ ShowWeekly = showWeekly, ShowWeeklyBands1 = showWeeklyBands1, ShowWeeklyBands2 = showWeeklyBands2, ShowSession = showSession, ShowAnchored = showAnchored, AnchorDate = anchorDate, AnchorTime = anchorTime }, input, ref cachea1);
-		}
+                public a1 a1(ISeries<double> input, bool showWeekly, bool showWeeklyBands1, bool showWeeklyBands2, bool showSession, bool showSessionBands1, bool showSessionBands2, bool showAnchored, DateTime anchorDate, string anchorTime)
+                {
+                        if (cachea1 != null)
+                                for (int idx = 0; idx < cachea1.Length; idx++)
+                                        if (cachea1[idx] != null && cachea1[idx].ShowWeekly == showWeekly && cachea1[idx].ShowWeeklyBands1 == showWeeklyBands1 && cachea1[idx].ShowWeeklyBands2 == showWeeklyBands2 && cachea1[idx].ShowSession == showSession && cachea1[idx].ShowSessionBands1 == showSessionBands1 && cachea1[idx].ShowSessionBands2 == showSessionBands2 && cachea1[idx].ShowAnchored == showAnchored && cachea1[idx].AnchorDate == anchorDate && cachea1[idx].AnchorTime == anchorTime && cachea1[idx].EqualsInput(input))
+                                                return cachea1[idx];
+                        return CacheIndicator<a1>(new a1(){ ShowWeekly = showWeekly, ShowWeeklyBands1 = showWeeklyBands1, ShowWeeklyBands2 = showWeeklyBands2, ShowSession = showSession, ShowSessionBands1 = showSessionBands1, ShowSessionBands2 = showSessionBands2, ShowAnchored = showAnchored, AnchorDate = anchorDate, AnchorTime = anchorTime }, input, ref cachea1);
+                }
 	}
 }
 
@@ -212,15 +257,15 @@ namespace NinjaTrader.NinjaScript.MarketAnalyzerColumns
 {
 	public partial class MarketAnalyzerColumn : MarketAnalyzerColumnBase
 	{
-		public Indicators.a1 a1(bool showWeekly, bool showWeeklyBands1, bool showWeeklyBands2, bool showSession, bool showAnchored, DateTime anchorDate, string anchorTime)
-		{
-			return indicator.a1(Input, showWeekly, showWeeklyBands1, showWeeklyBands2, showSession, showAnchored, anchorDate, anchorTime);
-		}
+                public Indicators.a1 a1(bool showWeekly, bool showWeeklyBands1, bool showWeeklyBands2, bool showSession, bool showSessionBands1, bool showSessionBands2, bool showAnchored, DateTime anchorDate, string anchorTime)
+                {
+                        return indicator.a1(Input, showWeekly, showWeeklyBands1, showWeeklyBands2, showSession, showSessionBands1, showSessionBands2, showAnchored, anchorDate, anchorTime);
+                }
 
-		public Indicators.a1 a1(ISeries<double> input , bool showWeekly, bool showWeeklyBands1, bool showWeeklyBands2, bool showSession, bool showAnchored, DateTime anchorDate, string anchorTime)
-		{
-			return indicator.a1(input, showWeekly, showWeeklyBands1, showWeeklyBands2, showSession, showAnchored, anchorDate, anchorTime);
-		}
+                public Indicators.a1 a1(ISeries<double> input , bool showWeekly, bool showWeeklyBands1, bool showWeeklyBands2, bool showSession, bool showSessionBands1, bool showSessionBands2, bool showAnchored, DateTime anchorDate, string anchorTime)
+                {
+                        return indicator.a1(input, showWeekly, showWeeklyBands1, showWeeklyBands2, showSession, showSessionBands1, showSessionBands2, showAnchored, anchorDate, anchorTime);
+                }
 	}
 }
 
@@ -228,15 +273,15 @@ namespace NinjaTrader.NinjaScript.Strategies
 {
 	public partial class Strategy : NinjaTrader.Gui.NinjaScript.StrategyRenderBase
 	{
-		public Indicators.a1 a1(bool showWeekly, bool showWeeklyBands1, bool showWeeklyBands2, bool showSession, bool showAnchored, DateTime anchorDate, string anchorTime)
-		{
-			return indicator.a1(Input, showWeekly, showWeeklyBands1, showWeeklyBands2, showSession, showAnchored, anchorDate, anchorTime);
-		}
+                public Indicators.a1 a1(bool showWeekly, bool showWeeklyBands1, bool showWeeklyBands2, bool showSession, bool showSessionBands1, bool showSessionBands2, bool showAnchored, DateTime anchorDate, string anchorTime)
+                {
+                        return indicator.a1(Input, showWeekly, showWeeklyBands1, showWeeklyBands2, showSession, showSessionBands1, showSessionBands2, showAnchored, anchorDate, anchorTime);
+                }
 
-		public Indicators.a1 a1(ISeries<double> input , bool showWeekly, bool showWeeklyBands1, bool showWeeklyBands2, bool showSession, bool showAnchored, DateTime anchorDate, string anchorTime)
-		{
-			return indicator.a1(input, showWeekly, showWeeklyBands1, showWeeklyBands2, showSession, showAnchored, anchorDate, anchorTime);
-		}
+                public Indicators.a1 a1(ISeries<double> input , bool showWeekly, bool showWeeklyBands1, bool showWeeklyBands2, bool showSession, bool showSessionBands1, bool showSessionBands2, bool showAnchored, DateTime anchorDate, string anchorTime)
+                {
+                        return indicator.a1(input, showWeekly, showWeeklyBands1, showWeeklyBands2, showSession, showSessionBands1, showSessionBands2, showAnchored, anchorDate, anchorTime);
+                }
 	}
 }
 


### PR DESCRIPTION
## Summary
- add optional ±1σ and ±2σ bands for session VWAP
- reset and compute session variance
- update default colors for session and anchored VWAP
- extend generated helper methods with new parameters

## Testing
- `dotnet build` *(fails: `dotnet: command not found`)*