### PR TITLE
Update a14 indicator logic

### DIFF
--- a/Indicators/a14.cs
+++ b/Indicators/a14.cs
@@ -10,148 +10,187 @@ using SharpDX.DirectWrite;
 
 namespace NinjaTrader.NinjaScript.Indicators
 {
-    // a14 – VWAP touch and ATR range monitor
+    // a14 – VWAP-touch + ATR-range monitor (v2.2 mod)
     public class a14 : Indicator
     {
-        private const int ATRPeriod = 14;
+        // ─── CONST ─────────────────────────────────────────────────────
+        private const int  ATRPeriod  = 14;
         private const float LabelWidth = 90f;
 
-        private a1 vwap;
-        private ATR atr;
-        private Series<bool> touchedSeries;
-        private Series<bool> preAtrSeries;
-        private Series<bool> atrSeries;
-
+        // ─── PARAMETERS ─────────────────────────────────────────────────
         [NinjaScriptProperty]
-        [Display(Name = "ATRmultiplier", Order = 0, GroupName = "Parameters")]
+        [Display(Name="ATRmultiplier", Order=0, GroupName="Parameters")]
         public double ATRmultiplier { get; set; } = 0.65;
 
         [NinjaScriptProperty]
-        [Display(Name = "vwaptouchtolerance", Order = 1, GroupName = "Parameters")]
+        [Display(Name="VWAP touch tolerance (ticks)", Order=1, GroupName="Parameters")]
         public int VWAPTouchTolerance { get; set; } = 3;
 
+        // — VWAP Session —
+        [NinjaScriptProperty] [Display(Name="vwap central", Order=10, GroupName="VWAP – Sesión")]
+        public bool ShowSessionCentral { get; set; } = true;
+        [NinjaScriptProperty] [Display(Name="vwap Band 1", Order=11, GroupName="VWAP – Sesión")]
+        public bool ShowSessionBand1   { get; set; } = true;
+        [NinjaScriptProperty] [Display(Name="vwap Band 2", Order=12, GroupName="VWAP – Sesión")]
+        public bool ShowSessionBand2   { get; set; } = true;
+
+        // — VWAP Weekly —
+        [NinjaScriptProperty] [Display(Name="Weekly vwap central", Order=20, GroupName="VWAP – Weekly")]
+        public bool ShowWeeklyCentral  { get; set; } = true;
+        [NinjaScriptProperty] [Display(Name="Weekly vwap banda 1", Order=21, GroupName="VWAP – Weekly")]
+        public bool ShowWeeklyBand1    { get; set; } = true;
+        [NinjaScriptProperty] [Display(Name="Weekly vwap banda 2", Order=22, GroupName="VWAP – Weekly")]
+        public bool ShowWeeklyBand2    { get; set; } = true;
+
+        // — VWAP Anchored —
+        [NinjaScriptProperty] [Display(Name="Anchored vwap", Order=30, GroupName="VWAP – Anchored")]
+        public bool ShowAnchored       { get; set; } = false;
+        [NinjaScriptProperty] [Display(Name="fecha", Order=31, GroupName="VWAP – Anchored")]
+        public DateTime AnchorDate     { get; set; } = DateTime.Today;
+        [NinjaScriptProperty] [Display(Name="hora (HH:mm)", Order=32, GroupName="VWAP – Anchored")]
+        [RegularExpression("^([01]?[0-9]|2[0-3]):[0-5][0-9]$", ErrorMessage="Formato HH:mm")]
+        public string AnchorTime       { get; set; } = "00:00";
+
+        // ─── PRIVATE FIELDS ─────────────────────────────────────────────
+        private a1 vwap;
+        private ATR atr;
+        private Series<bool> touchedSeries;
+        private Series<bool> atrSeries;
+        private Series<int>  plotHit;         // índice plot tocado, -1 = ninguno
+
+        private readonly string[] plotName =
+        {
+            "Weekly", "+1σ W", "-1σ W", "+2σ W", "-2σ W",
+            "Session", "Anchored",
+            "+1σ S", "-1σ S", "+2σ S", "-2σ S"
+        };
+
+        // ─── OnStateChange ─────────────────────────────────────────────
         protected override void OnStateChange()
         {
             if (State == State.SetDefaults)
             {
-                Name                    = "a14";
-                Calculate               = Calculate.OnEachTick;
-                IsOverlay               = true;
-                DisplayInDataBox        = false;
-                DrawOnPricePanel        = false;
-                PaintPriceMarkers       = false;
+                Name              = "a14";
+                Calculate         = Calculate.OnEachTick;   // intrabar
+                IsOverlay         = true;
+                DisplayInDataBox  = false;
+                DrawOnPricePanel  = false;
+                PaintPriceMarkers = false;
             }
             else if (State == State.Configure)
             {
-                vwap = a1(true, true, false, false, false, DateTime.Today, "00:00");
-                atr  = ATR(ATRPeriod);
+                vwap = a1(
+                    ShowWeeklyCentral, ShowWeeklyBand1, ShowWeeklyBand2,
+                    ShowSessionCentral, ShowSessionBand1, ShowSessionBand2,
+                    ShowAnchored, AnchorDate, AnchorTime);
+
+                atr = ATR(ATRPeriod);
             }
             else if (State == State.DataLoaded)
             {
                 touchedSeries = new Series<bool>(this);
-                preAtrSeries  = new Series<bool>(this);
                 atrSeries     = new Series<bool>(this);
+                plotHit       = new Series<int>(this);
             }
         }
 
+        // ─── OnBarUpdate ───────────────────────────────────────────────
         protected override void OnBarUpdate()
         {
-            if (CurrentBar < ATRPeriod)
-                return;
+            if (CurrentBar < ATRPeriod) return;
 
             if (IsFirstTickOfBar)
             {
                 touchedSeries[0] = false;
-                preAtrSeries[0] = false;
-                atrSeries[0]    = false;
+                atrSeries[0]     = false;
+                plotHit[0]       = -1;
             }
 
+            // — Detección de toque intrabar —
             double tolerance = TickSize * VWAPTouchTolerance;
-            bool hit = false;
+            bool   hit    = false;
+            int    hitIdx = -1;
 
-            double val;
-            val = vwap.Values[0][0]; // weekly VWAP
-            if (!double.IsNaN(val) && High[0] >= val - tolerance && Low[0] <= val + tolerance)
-                hit = true;
-            val = vwap.Values[1][0];
-            if (!double.IsNaN(val) && High[0] >= val - tolerance && Low[0] <= val + tolerance)
-                hit = true;
-            val = vwap.Values[2][0];
-            if (!double.IsNaN(val) && High[0] >= val - tolerance && Low[0] <= val + tolerance)
-                hit = true;
-            val = vwap.Values[3][0];
-            if (!double.IsNaN(val) && High[0] >= val - tolerance && Low[0] <= val + tolerance)
-                hit = true;
-            val = vwap.Values[4][0];
-            if (!double.IsNaN(val) && High[0] >= val - tolerance && Low[0] <= val + tolerance)
-                hit = true;
-            val = vwap.Values[5][0];
-            if (!double.IsNaN(val) && High[0] >= val - tolerance && Low[0] <= val + tolerance)
-                hit = true;
-            val = vwap.Values[6][0];
-            if (!double.IsNaN(val) && High[0] >= val - tolerance && Low[0] <= val + tolerance)
-                hit = true;
+            (int idx, bool enabled)[] plots =
+            {
+                (0, ShowWeeklyCentral),
+                (1, ShowWeeklyBand1), (2, ShowWeeklyBand1),
+                (3, ShowWeeklyBand2), (4, ShowWeeklyBand2),
+                (5, ShowSessionCentral),
+                (7, ShowSessionBand1), (8, ShowSessionBand1),
+                (9, ShowSessionBand2), (10, ShowSessionBand2),
+                (6, ShowAnchored)
+            };
 
-            if (hit)
-                touchedSeries[0] = true;
+            foreach (var p in plots)
+            {
+                if (!p.enabled) continue;
 
+                double val = vwap.Values[p.idx][0];
+                if (!double.IsNaN(val)
+                    && High[0] >= val - tolerance
+                    && Low[0]  <= val + tolerance)
+                {
+                    hit    = true;
+                    hitIdx = p.idx;
+                    break;
+                }
+            }
+
+            touchedSeries[0] = hit;
+            plotHit[0]       = hitIdx;
+
+            // — Rangos ATR —
             double barRange = High[0] - Low[0];
             double atrVal   = atr[0];
-
-            if (barRange >= 0.7 * atrVal)
-                preAtrSeries[0] = true;
-            if (barRange >= ATRmultiplier * atrVal)
-                atrSeries[0] = true;
+            if (barRange >= ATRmultiplier * atrVal) atrSeries[0] = true;
         }
 
-        protected override void OnRender(ChartControl chartControl, ChartScale chartScale)
+        // ─── OnRender ─────────────────────────────────────────────────
+        protected override void OnRender(ChartControl cc, ChartScale cs)
         {
-            base.OnRender(chartControl, chartScale);
+            base.OnRender(cc, cs);
+            if (ChartBars == null || RenderTarget == null) return;
 
-            if (ChartBars == null || RenderTarget == null)
-                return;
+            int first = ChartBars.FromIndex, last = ChartBars.ToIndex;
+            float bw  = (float)cc.GetBarPaintWidth(ChartBars);
+            const float h = 18f;  float off = 5f;
 
-            int firstBar = ChartBars.FromIndex;
-            int lastBar  = ChartBars.ToIndex;
-            float barWidth = (float)chartControl.GetBarPaintWidth(ChartBars);
-
-            const float boxHeight = 12f;
-            float offset = 5f;
-
-            using (var fmt = new TextFormat(Core.Globals.DirectWriteFactory, "Arial", 10))
-            using (var textBrush = new SharpDX.Direct2D1.SolidColorBrush(RenderTarget, Color.Black))
-            using (var fillBrush = new SharpDX.Direct2D1.SolidColorBrush(RenderTarget, new Color(0.8f, 0.8f, 0.8f, 1f)))
-            using (var borderBrush = new SharpDX.Direct2D1.SolidColorBrush(RenderTarget, Color.Black))
+            using (var fmt = new TextFormat(Core.Globals.DirectWriteFactory,"Arial",9))
+            using (var txt = new SharpDX.Direct2D1.SolidColorBrush(RenderTarget, Color.Black))
+            using (var fill= new SharpDX.Direct2D1.SolidColorBrush(RenderTarget,new Color(0.8f,0.8f,0.8f,1f)))
+            using (var brd = new SharpDX.Direct2D1.SolidColorBrush(RenderTarget, Color.Black))
             {
-                for (int i = firstBar; i <= lastBar; i++)
+                for (int i = first; i <= last; i++)
                 {
-                    float xCenter = chartControl.GetXByBarIndex(ChartBars, i);
-                    float xLeft   = xCenter - barWidth / 2f;
-                    float xLabel  = xLeft - LabelWidth;
-                    float baseY   = (float)chartScale.GetYByValue(Highs[BarsInProgress].GetValueAt(i));
-                    float yTop    = baseY - offset - boxHeight * 3;
+                    float xC   = cc.GetXByBarIndex(ChartBars,i);
+                    float xL   = xC - bw/2f;
+                    float xLbl = xL - LabelWidth;
+                    float y0   = (float)cs.GetYByValue(Highs[BarsInProgress].GetValueAt(i)) - off - h*2;
 
-                    DrawBoxWithLabel(touchedSeries.GetValueAt(i), "vwap toco", xLeft, xLabel, yTop, barWidth, boxHeight, fmt, textBrush, fillBrush, borderBrush);
-                    DrawBoxWithLabel(preAtrSeries.GetValueAt(i), "preATRmultiplier", xLeft, xLabel, yTop + boxHeight, barWidth, boxHeight, fmt, textBrush, fillBrush, borderBrush);
-                    DrawBoxWithLabel(atrSeries.GetValueAt(i), "ATRmultiplier", xLeft, xLabel, yTop + 2 * boxHeight, barWidth, boxHeight, fmt, textBrush, fillBrush, borderBrush);
+                    string extra = plotHit.GetValueAt(i) >= 0 ? "\n" + plotName[plotHit.GetValueAt(i)] : "";
+
+                    DrawBox("vwap touch" + extra, touchedSeries.GetValueAt(i), xL, xLbl, y0, bw, h, fmt, txt, fill, brd);
+                    DrawBox("ATRmultiplier", touchedSeries.GetValueAt(i) && atrSeries.GetValueAt(i), xL, xLbl, y0 + h, bw, h, fmt, txt, fill, brd);
                 }
             }
         }
 
-        private void DrawBoxWithLabel(bool filled, string label, float xLeft, float xLabel, float yTop, float width, float height, TextFormat fmt,
-            SharpDX.Direct2D1.SolidColorBrush textBrush, SharpDX.Direct2D1.SolidColorBrush fillBrush, SharpDX.Direct2D1.SolidColorBrush borderBrush)
+        private void DrawBox(string label, bool filled, float xL, float xLbl, float y, float w, float h,
+                             TextFormat fmt, SharpDX.Direct2D1.SolidColorBrush txtB,
+                             SharpDX.Direct2D1.SolidColorBrush fillB,
+                             SharpDX.Direct2D1.SolidColorBrush brdB)
         {
-            var rect = new RectangleF(xLeft, yTop, width, height);
-            RenderTarget.DrawRectangle(rect, borderBrush, 1f);
-            if (filled)
-                RenderTarget.FillRectangle(rect, fillBrush);
+            var r = new RectangleF(xL, y, w, h);
+            RenderTarget.DrawRectangle(r, brdB, 1f);
+            if (filled) RenderTarget.FillRectangle(r, fillB);
 
-            using (var layout = new TextLayout(Core.Globals.DirectWriteFactory, label, fmt, LabelWidth, height))
+            using (var tl = new TextLayout(Core.Globals.DirectWriteFactory, label, fmt, LabelWidth, h*2))
             {
-                var m = layout.Metrics;
-                float tx = xLabel + (LabelWidth - m.Width) / 2f;
-                float ty = yTop + (height - m.Height) / 2f;
-                RenderTarget.DrawTextLayout(new Vector2(tx, ty), layout, textBrush);
+                var m = tl.Metrics;
+                float tx = xLbl + (LabelWidth - m.Width) / 2f;
+                float ty = y    + (h - m.Height) / 2f;
+                RenderTarget.DrawTextLayout(new Vector2(tx, ty), tl, txtB);
             }
         }
     }
@@ -164,18 +203,18 @@ namespace NinjaTrader.NinjaScript.Indicators
     public partial class Indicator : NinjaTrader.Gui.NinjaScript.IndicatorRenderBase
     {
         private a14[] cachea14;
-        public a14 a14(double aTRmultiplier, int vWAPTouchTolerance)
+        public a14 a14(double aTRmultiplier, int vWAPTouchTolerance, bool showSessionCentral, bool showSessionBand1, bool showSessionBand2, bool showWeeklyCentral, bool showWeeklyBand1, bool showWeeklyBand2, bool showAnchored, DateTime anchorDate, string anchorTime)
         {
-            return a14(Input, aTRmultiplier, vWAPTouchTolerance);
+            return a14(Input, aTRmultiplier, vWAPTouchTolerance, showSessionCentral, showSessionBand1, showSessionBand2, showWeeklyCentral, showWeeklyBand1, showWeeklyBand2, showAnchored, anchorDate, anchorTime);
         }
 
-        public a14 a14(ISeries<double> input, double aTRmultiplier, int vWAPTouchTolerance)
+        public a14 a14(ISeries<double> input, double aTRmultiplier, int vWAPTouchTolerance, bool showSessionCentral, bool showSessionBand1, bool showSessionBand2, bool showWeeklyCentral, bool showWeeklyBand1, bool showWeeklyBand2, bool showAnchored, DateTime anchorDate, string anchorTime)
         {
             if (cachea14 != null)
                 for (int idx = 0; idx < cachea14.Length; idx++)
-                    if (cachea14[idx] != null && cachea14[idx].ATRmultiplier == aTRmultiplier && cachea14[idx].VWAPTouchTolerance == vWAPTouchTolerance && cachea14[idx].EqualsInput(input))
+                    if (cachea14[idx] != null && cachea14[idx].ATRmultiplier == aTRmultiplier && cachea14[idx].VWAPTouchTolerance == vWAPTouchTolerance && cachea14[idx].ShowSessionCentral == showSessionCentral && cachea14[idx].ShowSessionBand1 == showSessionBand1 && cachea14[idx].ShowSessionBand2 == showSessionBand2 && cachea14[idx].ShowWeeklyCentral == showWeeklyCentral && cachea14[idx].ShowWeeklyBand1 == showWeeklyBand1 && cachea14[idx].ShowWeeklyBand2 == showWeeklyBand2 && cachea14[idx].ShowAnchored == showAnchored && cachea14[idx].AnchorDate == anchorDate && cachea14[idx].AnchorTime == anchorTime && cachea14[idx].EqualsInput(input))
                         return cachea14[idx];
-            return CacheIndicator<a14>(new a14(){ ATRmultiplier = aTRmultiplier, VWAPTouchTolerance = vWAPTouchTolerance }, input, ref cachea14);
+            return CacheIndicator<a14>(new a14(){ ATRmultiplier = aTRmultiplier, VWAPTouchTolerance = vWAPTouchTolerance, ShowSessionCentral = showSessionCentral, ShowSessionBand1 = showSessionBand1, ShowSessionBand2 = showSessionBand2, ShowWeeklyCentral = showWeeklyCentral, ShowWeeklyBand1 = showWeeklyBand1, ShowWeeklyBand2 = showWeeklyBand2, ShowAnchored = showAnchored, AnchorDate = anchorDate, AnchorTime = anchorTime }, input, ref cachea14);
         }
     }
 }
@@ -184,14 +223,14 @@ namespace NinjaTrader.NinjaScript.MarketAnalyzerColumns
 {
     public partial class MarketAnalyzerColumn : MarketAnalyzerColumnBase
     {
-        public Indicators.a14 a14(double aTRmultiplier, int vWAPTouchTolerance)
+        public Indicators.a14 a14(double aTRmultiplier, int vWAPTouchTolerance, bool showSessionCentral, bool showSessionBand1, bool showSessionBand2, bool showWeeklyCentral, bool showWeeklyBand1, bool showWeeklyBand2, bool showAnchored, DateTime anchorDate, string anchorTime)
         {
-            return indicator.a14(Input, aTRmultiplier, vWAPTouchTolerance);
+            return indicator.a14(Input, aTRmultiplier, vWAPTouchTolerance, showSessionCentral, showSessionBand1, showSessionBand2, showWeeklyCentral, showWeeklyBand1, showWeeklyBand2, showAnchored, anchorDate, anchorTime);
         }
 
-        public Indicators.a14 a14(ISeries<double> input , double aTRmultiplier, int vWAPTouchTolerance)
+        public Indicators.a14 a14(ISeries<double> input , double aTRmultiplier, int vWAPTouchTolerance, bool showSessionCentral, bool showSessionBand1, bool showSessionBand2, bool showWeeklyCentral, bool showWeeklyBand1, bool showWeeklyBand2, bool showAnchored, DateTime anchorDate, string anchorTime)
         {
-            return indicator.a14(input, aTRmultiplier, vWAPTouchTolerance);
+            return indicator.a14(input, aTRmultiplier, vWAPTouchTolerance, showSessionCentral, showSessionBand1, showSessionBand2, showWeeklyCentral, showWeeklyBand1, showWeeklyBand2, showAnchored, anchorDate, anchorTime);
         }
     }
 }
@@ -200,14 +239,14 @@ namespace NinjaTrader.NinjaScript.Strategies
 {
     public partial class Strategy : NinjaTrader.Gui.NinjaScript.StrategyRenderBase
     {
-        public Indicators.a14 a14(double aTRmultiplier, int vWAPTouchTolerance)
+        public Indicators.a14 a14(double aTRmultiplier, int vWAPTouchTolerance, bool showSessionCentral, bool showSessionBand1, bool showSessionBand2, bool showWeeklyCentral, bool showWeeklyBand1, bool showWeeklyBand2, bool showAnchored, DateTime anchorDate, string anchorTime)
         {
-            return indicator.a14(Input, aTRmultiplier, vWAPTouchTolerance);
+            return indicator.a14(Input, aTRmultiplier, vWAPTouchTolerance, showSessionCentral, showSessionBand1, showSessionBand2, showWeeklyCentral, showWeeklyBand1, showWeeklyBand2, showAnchored, anchorDate, anchorTime);
         }
 
-        public Indicators.a14 a14(ISeries<double> input , double aTRmultiplier, int vWAPTouchTolerance)
+        public Indicators.a14 a14(ISeries<double> input , double aTRmultiplier, int vWAPTouchTolerance, bool showSessionCentral, bool showSessionBand1, bool showSessionBand2, bool showWeeklyCentral, bool showWeeklyBand1, bool showWeeklyBand2, bool showAnchored, DateTime anchorDate, string anchorTime)
         {
-            return indicator.a14(input, aTRmultiplier, vWAPTouchTolerance);
+            return indicator.a14(input, aTRmultiplier, vWAPTouchTolerance, showSessionCentral, showSessionBand1, showSessionBand2, showWeeklyCentral, showWeeklyBand1, showWeeklyBand2, showAnchored, anchorDate, anchorTime);
         }
     }
 }


### PR DESCRIPTION
## Summary
- implement advanced VWAP settings in a14 indicator
- remove preATR box and show ATR signal only on VWAP touch
- enlarge indicator boxes

## Testing
- `dotnet build -v:q` *(fails: `dotnet` not found)*